### PR TITLE
Split client cert manager from libp2p host

### DIFF
--- a/client/acme.go
+++ b/client/acme.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
-	httppeeridauth "github.com/libp2p/go-libp2p/p2p/http/auth"
 	"io"
 	"net"
 	"net/http"
@@ -12,16 +11,16 @@ import (
 	"sync"
 	"time"
 
+	httppeeridauth "github.com/libp2p/go-libp2p/p2p/http/auth"
+	"go.uber.org/fx"
+
 	"github.com/caddyserver/certmagic"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
-	libp2pquic "github.com/libp2p/go-libp2p/p2p/transport/quic"
-	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
-	libp2pwebrtc "github.com/libp2p/go-libp2p/p2p/transport/webrtc"
+	"github.com/libp2p/go-libp2p/p2p/transport/websocket"
 	libp2pws "github.com/libp2p/go-libp2p/p2p/transport/websocket"
-	libp2pwebtransport "github.com/libp2p/go-libp2p/p2p/transport/webtransport"
 	"github.com/mholt/acmez/v2"
 	"github.com/mholt/acmez/v2/acme"
 	"github.com/multiformats/go-multiaddr"
@@ -32,219 +31,33 @@ import (
 var log = logging.Logger("p2p-forge/client")
 
 type P2PForgeCertMgr struct {
+	ctx                       context.Context
+	cancel                    func()
 	forgeDomain               string
 	forgeRegistrationEndpoint string
+	provideHost               func(host.Host)
+	hostFn                    func() host.Host
 	cfg                       *certmagic.Config
-	h                         *hostWrapper
-}
-
-type hostWrapper struct {
-	host.Host
-}
-
-type hostCloseWrapper struct {
-	host.Host
-	closeFn func() error
-}
-
-func (h hostCloseWrapper) Close() error {
-	return h.closeFn()
 }
 
 type P2PForgeHostConfig struct {
 	certMgrOpts            []P2PForgeCertMgrOptions
-	onCertLoaded           func()
 	allowPrivateForgeAddrs bool
-	libp2pOpts             []libp2p.Option
 }
 
-type P2PForgeHostOptions func(*P2PForgeHostConfig) error
+type P2PForgeHostOptions func(*P2PForgeHostConfig)
 
 func WithP2PForgeCertMgrOptions(opts ...P2PForgeCertMgrOptions) P2PForgeHostOptions {
-	return func(h *P2PForgeHostConfig) error {
+	return func(h *P2PForgeHostConfig) {
 		h.certMgrOpts = append(h.certMgrOpts, opts...)
-		return nil
-	}
-}
-
-func WithLibp2pOptions(opts ...libp2p.Option) P2PForgeHostOptions {
-	return func(h *P2PForgeHostConfig) error {
-		h.libp2pOpts = append(h.libp2pOpts, opts...)
-		return nil
-	}
-}
-
-func WithOnCertLoaded(fn func()) P2PForgeHostOptions {
-	return func(h *P2PForgeHostConfig) error {
-		h.onCertLoaded = fn
-		return nil
 	}
 }
 
 // WithAllowPrivateForgeAddrs is meant for testing
 func WithAllowPrivateForgeAddrs() P2PForgeHostOptions {
-	return func(h *P2PForgeHostConfig) error {
+	return func(h *P2PForgeHostConfig) {
 		h.allowPrivateForgeAddrs = true
-		return nil
 	}
-}
-
-func NewHostWithP2PForge(opts ...P2PForgeHostOptions) (host.Host, error) {
-	cfg := &P2PForgeHostConfig{}
-	for _, opt := range opts {
-		if err := opt(cfg); err != nil {
-			return nil, err
-		}
-	}
-
-	certMgr, err := NewP2PForgeCertMgr(cfg.certMgrOpts...)
-	if err != nil {
-		return nil, err
-	}
-	tlsCfg := certMgr.cfg.TLSConfig()
-	tlsCfg.NextProtos = []string{"h2", "http/1.1"} // remove the ACME ALPN and set the HTTP 1.1 and 2 ALPNs
-	forgeDomain := certMgr.forgeDomain
-
-	var p2pForgeWssComponent = multiaddr.StringCast(fmt.Sprintf("/tls/sni/*.%s/ws", forgeDomain))
-
-	var h host.Host
-	var mx sync.RWMutex
-	// TODO: Option passing mechanism here isn't respectful of which transports the user wants to support or the addresses they want to listen on
-	hTmp, err := libp2p.New(libp2p.ChainOptions(libp2p.ChainOptions(cfg.libp2pOpts...),
-		libp2p.DefaultListenAddrs,
-		libp2p.ListenAddrStrings([]string{ // TODO: Grab these addresses from a TCP listener and share the ports
-			fmt.Sprintf("/ip4/0.0.0.0/tcp/0/tls/sni/*.%s/ws", forgeDomain),
-			fmt.Sprintf("/ip6/::/tcp/0/tls/sni/*.%s/ws", forgeDomain),
-		}...),
-		libp2p.Transport(tcp.NewTCPTransport),
-		libp2p.Transport(libp2pquic.NewTransport),
-		libp2p.Transport(libp2pws.New, libp2pws.WithTLSConfig(tlsCfg)),
-		libp2p.Transport(libp2pwebtransport.New),
-		libp2p.Transport(libp2pwebrtc.New),
-		libp2p.AddrsFactory(func(multiaddrs []multiaddr.Multiaddr) []multiaddr.Multiaddr {
-			mx.RLock()
-			if h == nil {
-				mx.RUnlock()
-				return multiaddrs
-			}
-			mx.RUnlock()
-
-			retAddrs := make([]multiaddr.Multiaddr, len(multiaddrs))
-			for i, a := range multiaddrs {
-				if isRelayAddr(a) || (!cfg.allowPrivateForgeAddrs && isPublicAddr(a)) {
-					retAddrs[i] = a
-					continue
-				}
-
-				// We expect the address to be of the form: /ipX/<IP address>/tcp/<Port>/tls/sni/*.<forge-domain>/ws
-				// We'll then replace the * with the IP address
-				withoutForgeWSS := a.Decapsulate(p2pForgeWssComponent)
-				if withoutForgeWSS.Equal(a) {
-					retAddrs[i] = a
-					continue
-				}
-
-				index := 0
-				var escapedIPStr string
-				var ipMaStr string
-				var tcpPortStr string
-				multiaddr.ForEach(withoutForgeWSS, func(c multiaddr.Component) bool {
-					switch index {
-					case 0:
-						switch c.Protocol().Code {
-						case multiaddr.P_IP4:
-							ipMaStr = c.String()
-							ipAddr := c.Value()
-							escapedIPStr = strings.ReplaceAll(ipAddr, ".", "-")
-						case multiaddr.P_IP6:
-							ipMaStr = c.String()
-							ipAddr := c.Value()
-							escapedIPStr = strings.ReplaceAll(ipAddr, ":", "-")
-							if escapedIPStr[0] == '-' {
-								escapedIPStr = "0" + escapedIPStr
-							}
-							if escapedIPStr[len(escapedIPStr)-1] == '-' {
-								escapedIPStr = escapedIPStr + "0"
-							}
-						default:
-							return false
-						}
-					case 1:
-						if c.Protocol().Code != multiaddr.P_TCP {
-							return false
-						}
-						tcpPortStr = c.Value()
-					default:
-						index++
-						return false
-					}
-					index++
-					return true
-				})
-				if index != 2 || escapedIPStr == "" || tcpPortStr == "" {
-					retAddrs[i] = a
-					continue
-				}
-
-				pidStr := peer.ToCid(h.ID()).Encode(multibase.MustNewEncoder(multibase.Base36))
-
-				newMaStr := fmt.Sprintf("%s/tcp/%s/tls/sni/%s.%s.%s/ws", ipMaStr, tcpPortStr, escapedIPStr, pidStr, forgeDomain)
-				newMA, err := multiaddr.NewMultiaddr(newMaStr)
-				if err != nil {
-					log.Errorf("error creating new multiaddr from %q: %s", newMaStr, err.Error())
-					retAddrs[i] = a
-					continue
-				}
-				retAddrs[i] = newMA
-			}
-			return retAddrs
-		}),
-	))
-	if err != nil {
-		return nil, err
-	}
-	mx.Lock()
-	h = hTmp
-	mx.Unlock()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	if err := certMgr.Run(ctx, h); err != nil {
-		cancel()
-		return nil, err
-	}
-
-	w := &hostCloseWrapper{Host: h, closeFn: func() error {
-		cancel()
-		err := h.Close()
-		return err
-	}}
-
-	if cfg.onCertLoaded != nil {
-		pidStr := peer.ToCid(h.ID()).Encode(multibase.MustNewEncoder(multibase.Base36))
-		certName := fmt.Sprintf("*.%s.%s", pidStr, forgeDomain)
-		_ = certName
-		certMgr.cfg.OnEvent = func(ctx context.Context, event string, data map[string]any) error {
-			if event == "cached_managed_cert" {
-				sans, ok := data["sans"]
-				if !ok {
-					return nil
-				}
-				sanList, ok := sans.([]string)
-				if !ok {
-					return nil
-				}
-				for _, san := range sanList {
-					if san == certName {
-						cfg.onCertLoaded()
-					}
-				}
-				return nil
-			}
-			return nil
-		}
-	}
-
-	return w, nil
 }
 
 func isRelayAddr(a multiaddr.Multiaddr) bool {
@@ -256,25 +69,18 @@ func isRelayAddr(a multiaddr.Multiaddr) bool {
 	return found
 }
 
-var publicCIDR6 = "2000::/3"
-var public6 *net.IPNet
-
-func init() {
-	_, public6, _ = net.ParseCIDR(publicCIDR6)
-}
-
 // isPublicAddr follows the logic of manet.IsPublicAddr, except it uses
-// a stricter definition of "public" for ipv6: namely "is it in 2000::/3"?
+// a stricter definition of "public" for ipv6 by excluding nat64 addresses.
 func isPublicAddr(a multiaddr.Multiaddr) bool {
 	ip, err := manet.ToIP(a)
 	if err != nil {
 		return false
 	}
 	if ip.To4() != nil {
-		return !inAddrRange(ip, manet.Private4) && !inAddrRange(ip, manet.Unroutable4)
+		return manet.IsPublicAddr(a)
 	}
 
-	return public6.Contains(ip)
+	return manet.IsPublicAddr(a) && !manet.IsNAT64IPv4ConvertedIPv6Addr(a)
 }
 
 func inAddrRange(ip net.IP, ipnets []*net.IPNet) bool {
@@ -295,9 +101,17 @@ type P2PForgeCertMgrConfig struct {
 	trustedRoots              *x509.CertPool
 	storage                   certmagic.Storage
 	modifyForgeRequest        func(r *http.Request) error
+	onCertLoaded              func()
 }
 
 type P2PForgeCertMgrOptions func(*P2PForgeCertMgrConfig) error
+
+func WithOnCertLoaded(fn func()) P2PForgeCertMgrOptions {
+	return func(config *P2PForgeCertMgrConfig) error {
+		config.onCertLoaded = fn
+		return nil
+	}
+}
 
 func WithForgeDomain(domain string) P2PForgeCertMgrOptions {
 	return func(config *P2PForgeCertMgrConfig) error {
@@ -387,32 +201,110 @@ func NewP2PForgeCertMgr(opts ...P2PForgeCertMgrOptions) (*P2PForgeCertMgr, error
 
 	certCfg := certmagic.NewDefault()
 	certCfg.Storage = mgrCfg.storage
-	h := &hostWrapper{}
+	hostChan := make(chan host.Host, 1)
+	provideHost := func(host host.Host) { hostChan <- host }
+	hostVal := sync.OnceValue(func() host.Host {
+		return <-hostChan
+	})
 
 	myACME := certmagic.NewACMEIssuer(certCfg, certmagic.ACMEIssuer{ // TODO: UX around user passed emails + agreement
 		CA:           mgrCfg.caEndpoint,
 		Email:        mgrCfg.userEmail,
 		Agreed:       true,
-		DNS01Solver:  &dns01P2PForgeSolver{mgrCfg.forgeRegistrationEndpoint, h, mgrCfg.modifyForgeRequest},
+		DNS01Solver:  &dns01P2PForgeSolver{mgrCfg.forgeRegistrationEndpoint, hostVal, mgrCfg.modifyForgeRequest},
 		TrustedRoots: mgrCfg.trustedRoots,
 	})
 	certCfg.Issuers = []certmagic.Issuer{myACME}
-	return &P2PForgeCertMgr{mgrCfg.forgeDomain, mgrCfg.forgeRegistrationEndpoint, certCfg, h}, nil
+
+	if mgrCfg.onCertLoaded != nil {
+		certCfg.OnEvent = func(ctx context.Context, event string, data map[string]any) error {
+			if event == "cached_managed_cert" {
+				sans, ok := data["sans"]
+				if !ok {
+					return nil
+				}
+				sanList, ok := sans.([]string)
+				if !ok {
+					return nil
+				}
+				peerID := hostVal().ID()
+				pidStr := peer.ToCid(peerID).Encode(multibase.MustNewEncoder(multibase.Base36))
+				certName := fmt.Sprintf("*.%s.%s", pidStr, mgrCfg.forgeDomain)
+				for _, san := range sanList {
+					if san == certName {
+						mgrCfg.onCertLoaded()
+					}
+				}
+				return nil
+			}
+			return nil
+		}
+	}
+
+	return &P2PForgeCertMgr{
+		forgeDomain:               mgrCfg.forgeDomain,
+		forgeRegistrationEndpoint: mgrCfg.forgeRegistrationEndpoint,
+		provideHost:               provideHost,
+		hostFn:                    hostVal,
+		cfg:                       certCfg,
+	}, nil
 }
 
-func (m *P2PForgeCertMgr) Run(ctx context.Context, h host.Host) error {
-	m.h.Host = h
-	pb36 := peer.ToCid(h.ID()).Encode(multibase.MustNewEncoder(multibase.Base36))
+func (m *P2PForgeCertMgr) Start() error {
+	m.ctx, m.cancel = context.WithCancel(context.Background())
+	go func() {
+		pb36 := peer.ToCid(m.hostFn().ID()).Encode(multibase.MustNewEncoder(multibase.Base36))
 
-	if err := m.cfg.ManageAsync(ctx, []string{fmt.Sprintf("*.%s.%s", pb36, m.forgeDomain)}); err != nil {
-		return err
-	}
+		if err := m.cfg.ManageAsync(m.ctx, []string{fmt.Sprintf("*.%s.%s", pb36, m.forgeDomain)}); err != nil {
+			log.Error(err)
+		}
+	}()
 	return nil
+}
+
+func (m *P2PForgeCertMgr) Stop() {
+	m.cancel()
+}
+
+// WebSocketTransport returns a libp2p.Option that enables the WebSocket
+// transport for libp2p hosts with a TLS config managed by the P2PForgeCertMgr.
+func (m *P2PForgeCertMgr) WebSocketTransport(opts ...websocket.Option) libp2p.Option {
+	tlsCfg := m.cfg.TLSConfig()
+	tlsCfg.NextProtos = []string{"h2", "http/1.1"} // remove the ACME ALPN and set the HTTP 1.1 and 2 ALPNs
+	return libp2p.Transport(libp2pws.New, libp2pws.WithTLSConfig(tlsCfg))
+}
+
+func (m *P2PForgeCertMgr) AddrStrings(opts ...websocket.Option) []string {
+	return []string{fmt.Sprintf("/ip4/0.0.0.0/tcp/0/tls/sni/*.%s/ws", m.forgeDomain),
+		fmt.Sprintf("/ip6/::/tcp/0/tls/sni/*.%s/ws", m.forgeDomain),
+	}
+}
+
+func (m *P2PForgeCertMgr) Libp2pOptions(opts ...P2PForgeHostOptions) libp2p.Option {
+	cfg := &P2PForgeHostConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	tlsCfg := m.cfg.TLSConfig()
+	tlsCfg.NextProtos = []string{"h2", "http/1.1"} // remove the ACME ALPN and set the HTTP 1.1 and 2 ALPNs
+	forgeDomain := m.forgeDomain
+
+	var p2pForgeWssComponent = multiaddr.StringCast(fmt.Sprintf("/tls/sni/*.%s/ws", forgeDomain))
+	return libp2p.ChainOptions(
+		libp2p.AddrsFactory(addrFactoryFn(func() peer.ID { return m.hostFn().ID() }, forgeDomain, cfg.allowPrivateForgeAddrs, p2pForgeWssComponent)),
+		// If we had an Fx option we could do this:
+		libp2p.WithFxOption(
+			fx.Invoke(func(host host.Host) {
+				m.provideHost(host)
+			}),
+		),
+	)
 }
 
 type dns01P2PForgeSolver struct {
 	forge              string
-	host               host.Host
+	hostVal            func() host.Host
 	modifyForgeRequest func(r *http.Request) error
 }
 
@@ -423,7 +315,8 @@ func (d *dns01P2PForgeSolver) Wait(ctx context.Context, challenge acme.Challenge
 }
 
 func (d *dns01P2PForgeSolver) Present(ctx context.Context, challenge acme.Challenge) error {
-	req, err := ChallengeRequest(ctx, d.forge, challenge.DNS01KeyAuthorization(), d.host.Addrs())
+	host := d.hostVal()
+	req, err := ChallengeRequest(ctx, d.forge, challenge.DNS01KeyAuthorization(), host.Addrs())
 	if err != nil {
 		return err
 	}
@@ -433,7 +326,7 @@ func (d *dns01P2PForgeSolver) Present(ctx context.Context, challenge acme.Challe
 		}
 	}
 
-	client := &httppeeridauth.ClientPeerIDAuth{PrivKey: d.host.Peerstore().PrivKey(d.host.ID())}
+	client := &httppeeridauth.ClientPeerIDAuth{PrivKey: host.Peerstore().PrivKey(host.ID())}
 	_, resp, err := client.AuthenticatedDo(http.DefaultClient, req)
 	if err != nil {
 		return err
@@ -452,3 +345,77 @@ func (d *dns01P2PForgeSolver) CleanUp(ctx context.Context, challenge acme.Challe
 
 var _ acmez.Solver = (*dns01P2PForgeSolver)(nil)
 var _ acmez.Waiter = (*dns01P2PForgeSolver)(nil)
+
+func addrFactoryFn(peerIDFn func() peer.ID, forgeDomain string, allowPrivateForgeAddrs bool, p2pForgeWssComponent multiaddr.Multiaddr) func(multiaddrs []multiaddr.Multiaddr) []multiaddr.Multiaddr {
+	return func(multiaddrs []multiaddr.Multiaddr) []multiaddr.Multiaddr {
+		retAddrs := make([]multiaddr.Multiaddr, len(multiaddrs))
+		for i, a := range multiaddrs {
+			if isRelayAddr(a) || (!allowPrivateForgeAddrs && isPublicAddr(a)) {
+				retAddrs[i] = a
+				continue
+			}
+
+			// We expect the address to be of the form: /ipX/<IP address>/tcp/<Port>/tls/sni/*.<forge-domain>/ws
+			// We'll then replace the * with the IP address
+			withoutForgeWSS := a.Decapsulate(p2pForgeWssComponent)
+			if withoutForgeWSS.Equal(a) {
+				retAddrs[i] = a
+				continue
+			}
+
+			index := 0
+			var escapedIPStr string
+			var ipMaStr string
+			var tcpPortStr string
+			multiaddr.ForEach(withoutForgeWSS, func(c multiaddr.Component) bool {
+				switch index {
+				case 0:
+					switch c.Protocol().Code {
+					case multiaddr.P_IP4:
+						ipMaStr = c.String()
+						ipAddr := c.Value()
+						escapedIPStr = strings.ReplaceAll(ipAddr, ".", "-")
+					case multiaddr.P_IP6:
+						ipMaStr = c.String()
+						ipAddr := c.Value()
+						escapedIPStr = strings.ReplaceAll(ipAddr, ":", "-")
+						if escapedIPStr[0] == '-' {
+							escapedIPStr = "0" + escapedIPStr
+						}
+						if escapedIPStr[len(escapedIPStr)-1] == '-' {
+							escapedIPStr = escapedIPStr + "0"
+						}
+					default:
+						return false
+					}
+				case 1:
+					if c.Protocol().Code != multiaddr.P_TCP {
+						return false
+					}
+					tcpPortStr = c.Value()
+				default:
+					index++
+					return false
+				}
+				index++
+				return true
+			})
+			if index != 2 || escapedIPStr == "" || tcpPortStr == "" {
+				retAddrs[i] = a
+				continue
+			}
+
+			pidStr := peer.ToCid(peerIDFn()).Encode(multibase.MustNewEncoder(multibase.Base36))
+
+			newMaStr := fmt.Sprintf("%s/tcp/%s/tls/sni/%s.%s.%s/ws", ipMaStr, tcpPortStr, escapedIPStr, pidStr, forgeDomain)
+			newMA, err := multiaddr.NewMultiaddr(newMaStr)
+			if err != nil {
+				log.Errorf("error creating new multiaddr from %q: %s", newMaStr, err.Error())
+				retAddrs[i] = a
+				continue
+			}
+			retAddrs[i] = newMA
+		}
+		return retAddrs
+	}
+}


### PR DESCRIPTION
I think this cleans things up a bit and composes better. But it requires a change to libp2p to expose passing in fx.Options directly.

An alternative to using fx.Option would be to create a new option that would give us a reference to the host earlier.