### PR TITLE
docs: readme references and docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+Corefile
+zones
+p2p-forge
+p2p-forge-certs/
+badger.libp2p-direct-challenges/

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,20 +42,13 @@ ENV P2P_FORGE_PATH="/p2p-forge"
 COPY --from=builder $GOPATH/bin/p2p-forge /usr/local/bin/p2p-forge
 COPY --from=builder $SRC_PATH/.github/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 
-# TODO: for now we bundle configuration, but can be customized by
-# mounting custom files on top of ones from image
-COPY --from=builder $SRC_PATH/Corefile $P2P_FORGE_PATH/Corefile
-COPY --from=builder $SRC_PATH/zones $P2P_FORGE_PATH/zones
-
 RUN mkdir -p $P2P_FORGE_PATH && \
   useradd -d $P2P_FORGE_PATH -u 1000 -G users p2pforge && \
   chown p2pforge:users $P2P_FORGE_PATH && \
   setcap cap_net_bind_service=+ep /usr/local/bin/p2p-forge
 
-VOLUME $P2P_FORGE_PATH
 WORKDIR $P2P_FORGE_PATH
 USER p2pforge
 EXPOSE 53 53/udp
-EXPOSE 443
 EXPOSE 9253
 ENTRYPOINT ["tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # p2p-forge
 
 
-> An Authoritative DNS server for distributing DNS subdomains to libp2p peers.
+> An Authoritative DNS server and API for distributing DNS subdomains with CA-signed TLS certificates to libp2p peers.
 
 <a href="http://ipshipyard.com/"><img align="right" src="https://github.com/user-attachments/assets/39ed3504-bb71-47f6-9bf8-cb9a1698f272" /></a>
 This is the backend of [`AutoTLS` feature introduced in Kubo 0.32.0-rc1](https://github.com/ipfs/kubo/blob/master/docs/config.md#autotls).  
@@ -15,7 +15,7 @@ The following diagrams show the high-level design of how p2p-forge works.
 
 ```mermaid
 sequenceDiagram
-    participant Client as Kubo (IPFS node)
+    participant Client as Kubo (libp2p peer)
     participant LE as Let's Encrypt (ACME Server)
     participant Registration as registration.libp2p.direct (p2p-forge/acme)
     participant DNS as libp2p.direct DNS (p2p-forge/acme)


### PR DESCRIPTION
- Simplified terms in High level diagrams by using real world endpoint / server names from `libp2p.direct
- Added some references below each diagram
- Cleaned up Docker image and updated related docs