### PR TITLE
feat: add ns3.libp2p.direct

### DIFF
--- a/zones/libp2p.direct
+++ b/zones/libp2p.direct
@@ -3,7 +3,7 @@ $ORIGIN libp2p.direct.
 
 ;; SOA Records
 @                               86400   IN      SOA     ns1.libp2p.direct. domains.ipshipyard.com. (
-                                                        2024091702  ; serial
+                                                        2024121101  ; serial
                                                         86400       ; refresh
                                                         2400        ; retry
                                                         604800      ; expire
@@ -13,6 +13,7 @@ $ORIGIN libp2p.direct.
 ;; DNS Service
 libp2p.direct.                  86400   IN      NS      ns1.libp2p.direct.
 libp2p.direct.                  86400   IN      NS      ns2.libp2p.direct.
+libp2p.direct.                  86400   IN      NS      ns3.libp2p.direct.
 libp2p.direct.                  86400   IN      NS      ns1.p2p-forge.dwebops.net.
 libp2p.direct.                  86400   IN      NS      ns2.p2p-forge.dwebops.net.
 
@@ -22,8 +23,11 @@ ns1.libp2p.direct.              86400   IN      A       40.160.8.207
 ns2.libp2p.direct.              86400   IN      A       15.204.28.76
 ;ns2.p2p-forge.dwebops.net.     86400   IN      AAAA    2604:2dc0:202:200::64e
 
+ns3.libp2p.direct.              86400   IN      A       18.188.47.119
+;ns3.libp2p.direct.             86400   IN      AAAA    2600:1f16:f2:9800:9fe5:445b:d8ae:efe3
+
 ;; TLS Provider
-libp2p.direct.				          86400   IN	    CAA	    0 issue "letsencrypt.org"
+libp2p.direct.                                    86400   IN        CAA     0 issue "letsencrypt.org"
 
 ;; HTTP Service
 registration.libp2p.direct.     86400   IN      NS      hera.ns.cloudflare.com.


### PR DESCRIPTION
Adding third NS (for now ipv4-only, to match glue records)


production updated at https://github.com/ipshipyard/waterworks-infra/pull/415