### PR TITLE
fix(ci): set UCI_GITHUB_TOKEN

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -15,3 +15,5 @@ concurrency:
 jobs:
   releaser:
     uses: ipdxco/unified-github-workflows/.github/workflows/releaser.yml@v1.0
+    secrets:
+      UCI_GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN }}


### PR DESCRIPTION
This aims to help with https://github.com/ipshipyard/p2p-forge/issues/14

The token is in repo, but was not used during release, and that is why the docker workflow did not get dispatched once tag was created by releaser.