### PR TITLE
feat: log if WithCAEndpoint(DefaultCATestEndpoint)

### DIFF
--- a/client/acme.go
+++ b/client/acme.go
@@ -241,6 +241,8 @@ func NewP2PForgeCertMgr(opts ...P2PForgeCertMgrOptions) (*P2PForgeCertMgr, error
 	}
 	if mgrCfg.caEndpoint == "" {
 		mgrCfg.caEndpoint = DefaultCAEndpoint
+	} else if mgrCfg.caEndpoint == DefaultCATestEndpoint {
+		mgrCfg.log.Errorf("initialized WithCAEndpoint(DefaultCATestEndpoint) (%s): certificate will be issued for staging purposes and won't work correctly in web browser; make sure to change to WithCAEndpoint(DefaultCAEndpoint) (%s) before deploying to production or testing in web browser", DefaultCATestEndpoint, DefaultCAEndpoint)
 	}
 	if mgrCfg.forgeRegistrationEndpoint == "" {
 		if mgrCfg.forgeDomain == DefaultForgeDomain {

--- a/client/acme.go
+++ b/client/acme.go
@@ -242,7 +242,7 @@ func NewP2PForgeCertMgr(opts ...P2PForgeCertMgrOptions) (*P2PForgeCertMgr, error
 	if mgrCfg.caEndpoint == "" {
 		mgrCfg.caEndpoint = DefaultCAEndpoint
 	} else if mgrCfg.caEndpoint == DefaultCATestEndpoint {
-		mgrCfg.log.Errorf("initialized WithCAEndpoint(DefaultCATestEndpoint) (%s): certificate will be issued for staging purposes and won't work correctly in web browser; make sure to change to WithCAEndpoint(DefaultCAEndpoint) (%s) before deploying to production or testing in web browser", DefaultCATestEndpoint, DefaultCAEndpoint)
+		mgrCfg.log.Errorf("initialized with staging endpoint (%s): certificate won't work correctly in web browser; make sure to change to WithCAEndpoint(DefaultCAEndpoint) (%s) before deploying to production or testing in web browser", DefaultCATestEndpoint, DefaultCAEndpoint)
 	}
 	if mgrCfg.forgeRegistrationEndpoint == "" {
 		if mgrCfg.forgeDomain == DefaultForgeDomain {


### PR DESCRIPTION
This PR implements idea from
https://github.com/libp2p/go-libp2p/pull/3103#discussion_r1907628830 to ensure users who set up staging endpoint for testing are always aware of it and never ship test config  to production.

## Demo

Run p2p-forge/client `WithCAEndpoint(DefaultCATestEndpoint)`, it will log ERROR: 

`2025-01-08T20:31:08.330+0100	ERROR	example.autotls	client/acme.go:245	initialized WithCAEndpoint(DefaultCATestEndpoint) (https://acme-staging-v02.api.letsencrypt.org/directory): certificate will be issued for staging purposes and won't work correctly in web browser; make sure to change to WithCAEndpoint(DefaultCAEndpoint) (https://acme-v02.api.letsencrypt.org/directory) before deploying to production or testing in web browser`