### PR TITLE
feat: add dns addr to addrsfactory

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -606,7 +606,7 @@ func TestLibp2pACMEE2E(t *testing.T) {
 		if strings.Contains(as, "p2p-circuit") {
 			continue
 		}
-		if strings.Contains(as, "libp2p.direct/tcp/") && strings.Contains(as, "/tls/ws") {
+		if strings.Contains(as, "libp2p.direct/ws") {
 			dialAddr = addr
 			break
 		}

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -606,7 +606,7 @@ func TestLibp2pACMEE2E(t *testing.T) {
 		if strings.Contains(as, "p2p-circuit") {
 			continue
 		}
-		if strings.Contains(as, "libp2p.direct/ws") {
+		if strings.Contains(as, "libp2p.direct/tcp/") && strings.Contains(as, "/tls/ws") {
 			dialAddr = addr
 			break
 		}


### PR DESCRIPTION
[Lumina](https://github.com/eigerco/lumina) nodes based on `rust-libp2p` are unable to connect to `/ipX/<ip>/tcp/<port>/tls/sni/<escapedIP>.<base36peerid>.libp2p.direct/ws/p2p/<peerid>`, but they are able to connect to `/dns/<escapedIP>.<base36peerid>.libp2p.direct/tcp/<port>/tls/ws/p2p/<peerid>`.

I am not sure whether `rust-libp2p` must have explicit support for `tls/sni/...` addresses, but adding dns multiaddrs solve the problem.

Are there any reasons why we wouldn't advertise dns multiaddrs?