### PR TITLE
fix(client): race in cert renewal

### DIFF
--- a/client/acme.go
+++ b/client/acme.go
@@ -289,6 +289,7 @@ func NewP2PForgeCertMgr(opts ...P2PForgeCertMgrOptions) (*P2PForgeCertMgr, error
 	})
 
 	// Wire up Issuer that does brokered DNS-01 ACME challenge
+	acmeLog := mgrCfg.log.Named("acme-broker")
 	brokeredDNS01Issuer := certmagic.NewACMEIssuer(mgr.certmagic, certmagic.ACMEIssuer{
 		CA:     mgrCfg.caEndpoint,
 		Email:  mgrCfg.userEmail,
@@ -300,10 +301,10 @@ func NewP2PForgeCertMgr(opts ...P2PForgeCertMgrOptions) (*P2PForgeCertMgr, error
 			modifyForgeRequest:         mgrCfg.modifyForgeRequest,
 			userAgent:                  mgrCfg.userAgent,
 			allowPrivateForgeAddresses: mgrCfg.allowPrivateForgeAddresses,
-			log:                        mgrCfg.log.Named("dns01solver"),
+			log:                        acmeLog.Named("dns01solver"),
 		},
 		TrustedRoots: mgrCfg.trustedRoots,
-		Logger:       mgr.certmagic.Logger,
+		Logger:       acmeLog.Desugar(),
 	})
 	mgr.certmagic.Issuers = []certmagic.Issuer{brokeredDNS01Issuer}
 

--- a/client/defaults.go
+++ b/client/defaults.go
@@ -20,6 +20,8 @@ const (
 	// ForgeAuthHeader optional HTTP header that client should include when
 	// talking to a limited access registration endpoint
 	ForgeAuthHeader = "Forge-Authorization"
+
+	DefaultStorageLocation = "p2p-forge-certs"
 )
 
 // defaultUserAgent is used as a fallback to inform HTTP server which library


### PR DESCRIPTION
Fixes #28.

Previously, we had global `defaultCertCache` and relied on `GetConfigForCert`  recursively calling `newCertmagicConfig`, which was likely a surface for racy bug from #28 where p2p-forge instance was not fully wired up yet 

Using custom things with certmagic is pretty awkward due to circular dependency that shows only when custom config, cache, storage are issues are used. 

In this PR, the circular dependency is solved in alternative way:
1. replaced `newCertmagicConfig` with simpler `configGetter` that operates on final certmagic inside of manager – this removes recursion and racy surface for `certmagic.*Default*` logic which is used if any of required fields is not set yet
2. config returned by `P2PForgeCertMgr.TLSConfig()` now explicitly uses `P2PForgeCertMgr.certmagic.GetCertificate` to remove surface of any indirection

Together, surface for racy behavior should be removed, allowing user to have default certmagic doing some unrelated things, and then one or more lip2p with multiple instances of p2p-forge/client in their app, without interfering with each other.

### TODO

- [x] smoke test in autotls example from https://github.com/libp2p/go-libp2p/pull/3103
- [x] smoke test in kubo master 
- [x] ci is green 
- [x] renewal test