### PR TITLE
fix: adjust TTLs

### DIFF
--- a/acme/reader.go
+++ b/acme/reader.go
@@ -17,7 +17,8 @@ type acmeReader struct {
 	Datastore   datastore.Datastore
 }
 
-const ttl = 1 * time.Hour
+// The TTL for the _acme-challenge TXT record is as short as possible, typically 60 seconds or less.
+const ttl = 60 * time.Second
 
 // ServeDNS implements the plugin.Handler interface.
 func (p acmeReader) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -262,7 +262,7 @@ func TestSetACMEChallenge(t *testing.T) {
 	if r.Rcode != dns.RcodeSuccess || len(r.Answer) == 0 {
 		t.Fatalf("Expected successful reply, got %s", dns.RcodeToString[r.Rcode])
 	}
-	expectedAnswer := fmt.Sprintf(`%s	3600	IN	TXT	"%s"`, m.Question[0].Name, testChallenge)
+	expectedAnswer := fmt.Sprintf(`%s	60	IN	TXT	"%s"`, m.Question[0].Name, testChallenge)
 	if r.Answer[0].String() != expectedAnswer {
 		t.Fatalf("Expected %s reply, got %s", expectedAnswer, r.Answer[0].String())
 	}
@@ -363,7 +363,7 @@ func TestIPv4Lookup(t *testing.T) {
 				return
 			}
 
-			expectedAnswer := fmt.Sprintf(`%s	86400	IN	A	%s`, m.Question[0].Name, tt.expectedAddress)
+			expectedAnswer := fmt.Sprintf(`%s	604800	IN	A	%s`, m.Question[0].Name, tt.expectedAddress)
 			if r.Answer[0].String() != expectedAnswer {
 				t.Fatalf("Expected %s reply, got %s", expectedAnswer, r.Answer[0].String())
 			}
@@ -480,7 +480,7 @@ func TestIPv6Lookup(t *testing.T) {
 				return
 			}
 
-			expectedAnswer := fmt.Sprintf(`%s	86400	IN	AAAA	%s`, m.Question[0].Name, tt.expectedAddress)
+			expectedAnswer := fmt.Sprintf(`%s	604800	IN	AAAA	%s`, m.Question[0].Name, tt.expectedAddress)
 			if r.Answer[0].String() != expectedAnswer {
 				t.Fatalf("Expected %s reply, got %s", expectedAnswer, r.Answer[0].String())
 			}

--- a/ipparser/plugin.go
+++ b/ipparser/plugin.go
@@ -45,7 +45,9 @@ type ipParser struct {
 	ForgeDomain string
 }
 
-const ttl = 24 * time.Hour
+// The TTL for self-referential ip.peerid.etld A/AAAA records can be as long as possible.
+// We will be increasing this over time, as infrastructure ossifies.
+const ttl = 7 * 24 * time.Hour
 
 // ServeDNS implements the plugin.Handler interface.
 func (p ipParser) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {

--- a/zones/libp2p.direct
+++ b/zones/libp2p.direct
@@ -3,7 +3,7 @@ $ORIGIN libp2p.direct.
 
 ;; SOA Records
 @                               86400   IN      SOA     aws1.libp2p.direct. domains.ipshipyard.com. (
-                                                        2025011601  ; serial
+                                                        2025020101  ; serial
                                                         86400       ; refresh
                                                         2400        ; retry
                                                         604800      ; expire
@@ -41,9 +41,6 @@ ns1.libp2p.direct.              86400   IN      AAAA    2604:2dc0:101:100::265
 ;; dev2
 ns2.libp2p.direct.              86400   IN      A       15.204.28.76
 ns2.libp2p.direct.              86400   IN      AAAA    2604:2dc0:202:200::64e
-
-;; TODO: ns3 was renamed to aws1, fine to remove once we migrate away from ns1 as primary
-ns3.libp2p.direct.              86400   IN      CNAME   aws1.libp2p.direct.
 
 ;; Limit allowed CAs to Let's Encrypt, we discussed feasibility with them and no concerns were raised:
 ;; https://community.letsencrypt.org/t/feedback-on-raising-certificates-per-registered-domain-to-enable-peer-to-peer-networking/223003


### PR DESCRIPTION
Some initial fixes based on [ipfs-desktop rollout](https://github.com/ipfs/ipfs-desktop/releases/tag/v0.41.0):

- [x] increase TTL for generated `A` and `AAAA` (they never change)
- [x] decrease TTL for TXT at `_acme-challenge` to avoid caching-related failures and impacting how long it takes p2p-forge/client to have a successful retry on shared IPs
- [x] fix tests