### PR TITLE
chore(client): add readme

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,8 @@
+# AutoTLS client for go-libp2p nodes
+
+Code example:
+- [`github.com/libp2p/go-libp2p/tree/master/examples/autotls`](https://github.com/libp2p/go-libp2p/tree/master/examples/autotls) – The libp2p 'host' with Secure WebSockets and AutoTLS
+
+Extra reading: 
+- https://github.com/ipshipyard/p2p-forge#readme
+- https://blog.libp2p.io/autotls/


### PR DESCRIPTION
Basic readme pointing reader at go-libp2p code example.
Feel free to improve in follow-up PRs.