### PR TITLE
fix: increase TTLs for NODATA responses

### DIFF
--- a/acme/reader.go
+++ b/acme/reader.go
@@ -58,7 +58,7 @@ func (p acmeReader) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 		}
 
 		val, err := p.Datastore.Get(ctx, datastore.NewKey(peerID.String()))
-		if err != nil {
+		if err != nil || len(val) == 0 {
 			// return "empty" TXT record to have control over TTL that does not depend on minimal TTL from SOA
 			// (avoiding issue described in https://github.com/ipshipyard/p2p-forge/issues/52)
 			answers = append(answers, &dns.TXT{

--- a/acme/reader.go
+++ b/acme/reader.go
@@ -22,6 +22,9 @@ const (
 
 	// The TTL for the _acme-challenge TXT record is as short as possible
 	txtTTL = uint32(10) // seconds
+
+	// TXT value returned when broker has no DNS-01 value yet
+	DNS01NotSetValue = "not set yet"
 )
 
 // ServeDNS implements the plugin.Handler interface.
@@ -68,7 +71,7 @@ func (p acmeReader) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 					Class:  dns.ClassINET,
 					Ttl:    txtTTL,
 				},
-				Txt: []string{"not set yet"},
+				Txt: []string{DNS01NotSetValue},
 			})
 			// track "empty" TXT separately from NODATA (we do return a record, but DNS-01 value is not set yet)
 			dns01ResponseCount.WithLabelValues("TXT-EMPTY").Add(1)

--- a/zones/libp2p.direct
+++ b/zones/libp2p.direct
@@ -3,11 +3,11 @@ $ORIGIN libp2p.direct.
 
 ;; SOA Records
 @                               86400   IN      SOA     aws1.libp2p.direct. domains.ipshipyard.com. (
-                                                        2025020101  ; serial
+                                                        2025022501  ; serial
                                                         86400       ; refresh
                                                         2400        ; retry
                                                         604800      ; expire
-                                                        300         ; minimum
+                                                        86400       ; minimum (TTL for "no record" responses)
                                                         )
 
 ;; DNS Service


### PR DESCRIPTION
This PR aims to close #52  by:
- [x] increasing minimal TTL in SOA to 1 day (used for "record not found" scenarios
- [x] always returning valid TXT record from `_acme-challenge` subdomain with 10s TTL to ensure "not set yet" result is not cached for entire day