### PR TITLE
fix(client): filter out public /p2p-circuit addrs

### DIFF
--- a/client/acme.go
+++ b/client/acme.go
@@ -57,8 +57,17 @@ func isRelayAddr(a multiaddr.Multiaddr) bool {
 }
 
 // isPublicAddr follows the logic of manet.IsPublicAddr, except it uses
-// a stricter definition of "public" for ipv6 by excluding nat64 addresses.
+// a stricter definition of "public" for ipv6 by excluding nat64 addresses
+// and /p2p-circuit ones
 func isPublicAddr(a multiaddr.Multiaddr) bool {
+	// skip p2p-circuit ones
+	for _, p := range a.Protocols() {
+		if p.Code == multiaddr.P_CIRCUIT {
+			return false
+		}
+	}
+
+	// public vs private IPs
 	ip, err := manet.ToIP(a)
 	if err != nil {
 		return false

--- a/client/acme_test.go
+++ b/client/acme_test.go
@@ -1,0 +1,94 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/multiformats/go-multiaddr"
+)
+
+func TestIsPublicAddr(t *testing.T) {
+	tests := []struct {
+		name     string
+		addr     string
+		expected bool
+	}{
+		{
+			name:     "Public IPv4 address (Google DNS)",
+			addr:     "/ip4/8.8.8.8/tcp/4001",
+			expected: true,
+		},
+		{
+			name:     "Public IPv4 address (Cloudflare)",
+			addr:     "/ip4/1.1.1.1/tcp/4001",
+			expected: true,
+		},
+		{
+			name:     "Private IPv4 address (LAN 192.168.x.x)",
+			addr:     "/ip4/192.168.0.1/tcp/4001",
+			expected: false,
+		},
+		{
+			name:     "Private IPv4 address (LAN 10.x.x.x)",
+			addr:     "/ip4/10.0.0.1/tcp/4001",
+			expected: false,
+		},
+		{
+			name:     "Public IPv6 address (Google)",
+			addr:     "/ip6/2001:4860:4860::8888/tcp/4001",
+			expected: true,
+		},
+		{
+			name:     "Public IPv6 address (Cloudflare)",
+			addr:     "/ip6/2606:4700:4700::1111/tcp/4001",
+			expected: true,
+		},
+		{
+			name:     "NAT64 IPv6 address for LAN IP",
+			addr:     "/ip6/64:ff9b::192.0.2.1/tcp/4001",
+			expected: false,
+		},
+		{
+			name:     "libp2p Circuit relay address",
+			addr:     "/ip4/8.8.8.8/tcp/4001/p2p-circuit",
+			expected: false,
+		},
+		{
+			name:     "Invalid multiaddr",
+			addr:     "/invalid",
+			expected: false,
+		},
+		{
+			name:     "Localhost IPv4",
+			addr:     "/ip4/127.0.0.1/tcp/4001",
+			expected: false,
+		},
+		{
+			name:     "Localhost IPv6",
+			addr:     "/ip6/::1/tcp/4001",
+			expected: false,
+		},
+		{
+			name:     "Private IPv4 address (LAN 172.16.x.x)",
+			addr:     "/ip4/172.16.0.1/tcp/4001",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addr, err := multiaddr.NewMultiaddr(tt.addr)
+			if err != nil {
+				if tt.expected {
+					t.Fatalf("failed to parse multiaddr %q: %v", tt.addr, err)
+				}
+				// If parsing fails and expected is false, let isPublicAddr handle it
+				addr = nil
+			}
+			got := isPublicAddr(addr)
+			if got != tt.expected {
+				t.Errorf("isPublicAddr(%q) = %v; want %v", tt.addr, got, tt.expected)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
This PR updates `func isPublicAddr(a multiaddr.Multiaddr) bool` to return  `false` if multiaddr includes `/p2p-circuit`.

### Rationale

It is possible a node is in a state where relay addrs are still attached to libp2p host when registration is attempted.

In such case, it is better to end up with empty list of public addrs, and produce clear `no public address found` error, and then retry later, than waste time on registration that will fail with a vague spaghetti error: `p2p-forge broker registration error: 400 Bad Request error from https://registration.libp2p.direct/v1/_acme-challenge: \"error testing addresses: failed to dial: failed to dial 12D3KooWGU3fJrHaWtRSWyrrzCpdgFX5bxbS69hqL1MSdKMGez12: no good addresses\\n  * [/ip6/2602:294:0:8c::2/tcp/4001/p2p/12D3KooWKXK31VX9q49v1sfcTBBMTnJPNNMkSH2kAUzSGURQcYAN/p2p-circuit] no transport for protocol\\n  * [/ip6/2602:294:0:8c::2/udp/4001/webrtc-direct/certhash/uEiD1NE9t8pMLKAW42jo_ETe7Oyt9wk-QHIE3Ilr4jhFVmg/p2p/12D3KooWKXK31VX9q49v1sfcTBBMTnJPNNMkSH2kAUzSGURQcYAN/p2p-circuit] no transport for protocol\\n  * [/ip6/2602:294:0:8c::2/udp/4001/quic-v1/p2p/12D3KooWKXK31VX9q49v1sfcTBBMTnJPNNMkSH2kAUzSGURQcYAN/p2p-circuit] no transport for protocol\\n  * [/ip6/2602:294:0:8c::2/udp/4001/quic-v1/webtransport/certhash/uEiBA0nGhqrwTykjfR75LCGdPSQe0R6-67Z03VJ4nYY0QMA/certhash/uEiCHDdu4Y9uv_z031_ANtkngfq4HdSLuiCex6XKW7d55MQ/p2p/12D3KooWKXK31VX9q49v1sfcTBBMTnJPNNMkSH2kAUzSGURQcYAN/p2p-circuit] no transport for protocol`

cc @aschmahmann @hsanjuan 